### PR TITLE
Buffered metrics

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -14,7 +14,7 @@ var Client *statsd.Client
 func InitMetrics(statsAddr string) {
 	if Client == nil {
 		var err error
-		Client, err = statsd.New(statsAddr)
+		Client, err = statsd.NewBuffered(statsAddr, 500)
 		if err != nil {
 			logrus.Fatal(err)
 		}

--- a/pkg/protocol/beanProto.go
+++ b/pkg/protocol/beanProto.go
@@ -190,9 +190,7 @@ func (s *Server) serve(conn *Connection) {
 			if err != nil {
 				logrus.WithError(err).Fatal("error reading data")
 			}
-			data := make([]byte, len(body))
-			copy(data, body)
-			putCmd(conn, parts[1:], data[:])
+			putCmd(conn, parts[1:], body)
 		case reserve:
 			go metrics.Incr(reserveJobCtr)
 			reserveCmd(conn, "0")


### PR DESCRIPTION
Quick perf improvements:

- Flame graph showed that we were waiting on metrics sends in hot code paths, make it buffered and run them in go routines
- Minor fix: don't copy job body after read in bean protocol