### PR TITLE
Optimize map

### DIFF
--- a/pkg/goyaad/hub.go
+++ b/pkg/goyaad/hub.go
@@ -208,7 +208,6 @@ func (h *Hub) NextLocked() *Job {
 			h.currentSpoke = current
 			// Pop it from the queue - this is now a current spoke
 			heap.Pop(h.spokes)
-			log.Info().Int("spokesCapacity", h.spokes.Cap()).Msg("Hub spoke cap")
 		}
 	}
 
@@ -329,6 +328,7 @@ func (h *Hub) addJob(j *Job) error {
 
 // StatusLocked prints the state of the spokes of this hub
 func (h *Hub) StatusLocked() {
+	// TODO: this can be made to run unlocked at the hub level? by adding the spoken len to stats/Counter too
 	h.lock.Lock()
 	defer h.lock.Unlock()
 	log.Info().Msg("------------------------Hub Stats----------------------------")

--- a/pkg/goyaad/hub_test.go
+++ b/pkg/goyaad/hub_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Test hub", func() {
 				AttemptRestore: false})
 
 			j := NewJobAutoID(time.Now().Add(time.Millisecond*time.Duration(rand.Intn(999999))), nil)
-			h.AddJob(j)
+			h.AddJobLocked(j)
 
 			Expect(h.PendingJobsCount()).To(Equal(1))
 		}
@@ -74,14 +74,14 @@ var _ = Describe("Test hub", func() {
 
 		// Add all of them
 		for i, j := range jobs {
-			h.AddJob(j)
+			h.AddJobLocked(j)
 			Expect(h.PendingJobsCount()).To(Equal(i + 1))
 		}
 
 		// Walk should return all jobs in global order
 		walked := []*Job{}
 		for h.PendingJobsCount() > 0 {
-			walked = append(walked, h.Next())
+			walked = append(walked, h.NextLocked())
 		}
 
 		// Expect correct order
@@ -123,18 +123,18 @@ var _ = Describe("Test hub", func() {
 		jobMap := make(map[string]*Job, len(jobs))
 		// Add all of them
 		for i, j := range jobs {
-			h.AddJob(j)
+			h.AddJobLocked(j)
 			jobMap[j.ID()] = j
 			Expect(h.PendingJobsCount()).To(Equal(i + 1))
 		}
 
 		// Reserve some jobs
-		Expect(h.Next()).ToNot(BeNil())
-		Expect(h.Next()).ToNot(BeNil())
-		Expect(h.Next()).ToNot(BeNil())
+		Expect(h.NextLocked()).ToNot(BeNil())
+		Expect(h.NextLocked()).ToNot(BeNil())
+		Expect(h.NextLocked()).ToNot(BeNil())
 
 		// Persist
-		persistErrs := h.Persist()
+		persistErrs := h.PersistLocked()
 
 		// if any errors pop up, fail the test
 		for e := range persistErrs {

--- a/pkg/goyaad/stats/hubStats.go
+++ b/pkg/goyaad/stats/hubStats.go
@@ -11,8 +11,9 @@ type Counters struct {
 
 // Snapshot is a readonly view of the stats counters
 type Snapshot struct {
-	CurrentJobs int64 // current set of jobs
-	RemovedJobs int64 // jobs removed so far
+	CurrentJobs   int64 // current set of jobs
+	RemovedJobs   int64 // jobs removed so far
+	CurrentSpokes int64 // number of current spokes
 }
 
 // Read returns a "copy" of the current stats snapshot at that instant
@@ -20,6 +21,7 @@ func (c *Counters) Read() Snapshot {
 	r := Snapshot{}
 	r.CurrentJobs = atomic.LoadInt64(&c.s.CurrentJobs)
 	r.RemovedJobs = atomic.LoadInt64(&c.s.RemovedJobs)
+	r.CurrentSpokes = atomic.LoadInt64(&c.s.CurrentSpokes)
 	return r
 }
 
@@ -32,4 +34,14 @@ func (c *Counters) IncrJob() {
 func (c *Counters) DecrJob() {
 	atomic.AddInt64(&c.s.CurrentJobs, -1)
 	atomic.AddInt64(&c.s.RemovedJobs, 1)
+}
+
+// IncrSpoke updates counters - spoke has been added
+func (c *Counters) IncrSpoke() {
+	atomic.AddInt64(&c.s.CurrentSpokes, 1)
+}
+
+// DecrSpoke updates counter - spoke has been removed
+func (c *Counters) DecrSpoke() {
+	atomic.AddInt64(&c.s.CurrentSpokes, -1)
 }

--- a/pkg/goyaad/stats/hubStats.go
+++ b/pkg/goyaad/stats/hubStats.go
@@ -1,0 +1,35 @@
+package stats
+
+import "sync/atomic"
+
+// Counters are used to keep quick stats counters so that we can do
+// stats reporting without locking the hub and reading over the spokes
+// internal state should not be accessed directly
+type Counters struct {
+	s Snapshot
+}
+
+// Snapshot is a readonly view of the stats counters
+type Snapshot struct {
+	CurrentJobs int64 // current set of jobs
+	RemovedJobs int64 // jobs removed so far
+}
+
+// Read returns a "copy" of the current stats snapshot at that instant
+func (c *Counters) Read() Snapshot {
+	r := Snapshot{}
+	r.CurrentJobs = atomic.LoadInt64(&c.s.CurrentJobs)
+	r.RemovedJobs = atomic.LoadInt64(&c.s.RemovedJobs)
+	return r
+}
+
+// IncrJob updates counters - job has been added
+func (c *Counters) IncrJob() {
+	atomic.AddInt64(&c.s.CurrentJobs, 1)
+}
+
+// DecrJob updates counter - job has been removed
+func (c *Counters) DecrJob() {
+	atomic.AddInt64(&c.s.CurrentJobs, -1)
+	atomic.AddInt64(&c.s.RemovedJobs, 1)
+}


### PR DESCRIPTION
This branch has a bunch of performance fixes.
- Hub locks at the top, so moved back to regular `map` from `sync.Map` to avoid extra synchronization cost (for both hub and spokes)
- Made stats reporting lighter, doesn't need to lock hub for most part so that job can be enqueued/dequeued while stats reporter runs
- Methods that acquire locks are suffixed as `Locked` for better readability