### PR TITLE
Feature/mem accounting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/urjitbhatia/goyaad
 go 1.13
 
 require (
+	code.cloudfoundry.org/bytefmt v0.0.0-20200125003136-cc367df7c24e
 	github.com/DataDog/datadog-go v2.2.0+incompatible
 	github.com/dgryski/go-metro v0.0.0-20180109044635-280f6062b5bc // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
 cloud.google.com/go v0.39.0 h1:UgQP9na6OTfp4dsAiz/eFpFA1C6tPdH5wiRdi19tuMw=
 cloud.google.com/go v0.39.0/go.mod h1:rVLT6fkc8chs9sfPtFc1SBH6em7n+ZoXaG+87tDISts=
+code.cloudfoundry.org/bytefmt v0.0.0-20200125003136-cc367df7c24e h1:kmQrHuteOlV1uQ4fIyo8ZGxnW72VmY8i6kiRn4MgEMc=
+code.cloudfoundry.org/bytefmt v0.0.0-20200125003136-cc367df7c24e/go.mod h1:wN/zk7mhREp/oviagqUXY3EwuHhWyOvAdsn5Y4CzOrc=
 contrib.go.opencensus.io/exporter/aws v0.0.0-20181029163544-2befc13012d0/go.mod h1:uu1P0UCM/6RbsMrgPa98ll8ZcHM858i/AD06a9aLRCA=
 contrib.go.opencensus.io/exporter/ocagent v0.5.0 h1:TKXjQSRS0/cCDrP7KvkgU6SmILtF/yV2TOs/02K/WZQ=
 contrib.go.opencensus.io/exporter/ocagent v0.5.0/go.mod h1:ImxhfLRpxoYiSq891pBrLVhN+qmP8BTVvdH2YLs7Gl0=

--- a/internal/monitor/memAccountedJob.go
+++ b/internal/monitor/memAccountedJob.go
@@ -1,0 +1,125 @@
+package monitor
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"sync"
+	"sync/atomic"
+
+	"github.com/rs/zerolog/log"
+)
+
+// MemAccountable struct is one that wishes to enable mem accounting for itself
+type MemAccountable interface {
+	SizeOf() uintptr
+}
+
+// MemMonitor watches memory usages and provides alarms when usage breaches thresholds
+// Users of the monitor should call Fence() to stall operations while alarms are breached
+// Fence blocks till accounted memory usage falls below the recovery threshold which is lower
+// than the actual threshold to enable some breathing room
+type MemMonitor interface {
+	Increment(MemAccountable)
+	Decrement(MemAccountable)
+	Fence()
+}
+
+type noopMemMonitor struct{}
+
+type memMonitor struct {
+	current uintptr
+
+	threshold         uintptr
+	recoveryThreshold uintptr
+
+	breachCond *sync.Cond
+}
+
+var memMonitorInstance MemMonitor
+
+func init() {
+	// configure mem manager
+	if _, ok := os.LookupEnv("MEM_MAN_DISABLED"); ok {
+		UseNoopMemMonitor()
+		return
+	}
+
+	var threshold uint64
+	if t, ok := os.LookupEnv("MEM_MAN_SIZE"); ok {
+		var err error
+		threshold, err = strconv.ParseUint(t, 10, 64)
+		if err != nil {
+			log.Info().Msgf("Unparseable mem alarm size specified: %s Should be specified as number of bytes", t)
+		}
+		if threshold == 0 {
+			UseNoopMemMonitor()
+			return
+		}
+		configureMemMonitor(uintptr(threshold))
+		return
+	}
+	UseNoopMemMonitor()
+}
+
+// GetMemMonitor returns a ready mem monitor - Call ConfigureMemMonitor before this
+// otherwise this method will panic
+func GetMemMonitor() MemMonitor {
+	if memMonitorInstance == nil {
+		log.Fatal().Msg("GetMemMonitor called before ConfigureMemMonitor")
+	}
+	return memMonitorInstance
+}
+
+// configureMemMonitor sets a threshold value on a mem monitor.
+// Call this before GetMemMonitor and before allocating the observed structs.
+func configureMemMonitor(threshold uintptr) MemMonitor {
+	if memMonitorInstance == nil {
+		mm := &memMonitor{
+			threshold:         threshold,
+			recoveryThreshold: threshold - 4*(threshold>>10),
+			breachCond:        sync.NewCond(&sync.Mutex{}),
+		}
+		log.Info().
+			Str("AlarmThreshold", fmt.Sprintf("%d", mm.threshold)).
+			Str("AlarmRecoveryThreshold", fmt.Sprintf("%d", mm.recoveryThreshold)).
+			Msg("Initialized new memory monitor")
+		memMonitorInstance = mm
+	}
+	return memMonitorInstance
+}
+
+func (mm *memMonitor) Increment(a MemAccountable) {
+	atomic.AddUintptr(&mm.current, a.SizeOf())
+	if atomic.LoadUintptr(&mm.current) >= mm.threshold {
+		log.Warn().Msg("MemManager: breached mem threshold")
+	}
+}
+
+func (mm *memMonitor) Decrement(a MemAccountable) {
+	if atomic.AddUintptr(&mm.current, ^(a.SizeOf()-1)) < mm.recoveryThreshold {
+		mm.breachCond.L.Lock()
+		log.Warn().Msg("MemManager: recovered mem threshold")
+		mm.breachCond.Broadcast()
+		mm.breachCond.L.Unlock()
+	}
+}
+func (mm *memMonitor) Fence() {
+	// Fence blocks if above threshold
+	mm.breachCond.L.Lock()
+	for atomic.LoadUintptr(&mm.current) >= mm.threshold {
+		mm.breachCond.Wait()
+	}
+	mm.breachCond.L.Unlock()
+}
+
+// UseNoopMemMonitor creates a noop implementation of mem-monitor if we want to fully disable it
+// with minimal penalty
+func UseNoopMemMonitor() {
+	memMonitorInstance = &noopMemMonitor{}
+	log.Info().Msg("Using NOOP memory monitor")
+}
+
+func (n *noopMemMonitor) Increment(a MemAccountable) {}
+func (n *noopMemMonitor) Decrement(a MemAccountable) {}
+func (n *noopMemMonitor) Fence()                     {}

--- a/internal/monitor/memory.go
+++ b/internal/monitor/memory.go
@@ -99,9 +99,9 @@ func configureMemMonitor(watermark uint64) MemMonitor {
 			Str("AlarmRecoveryWatermark", bytefmt.ByteSize(mm.recoveryWatermark)).
 			Msg("Initialized new memory monitor")
 		memMonitorInstance = mm
-		go func()  {
+		go func() {
 			// sent metrics
-			for range time.NewTicker(time.Second*1).C {	
+			for range time.NewTicker(time.Second * 1).C {
 				metrics.Gauge("memmanager.watermark", float64(mm.watermark))
 				metrics.Gauge("memmanager.current", float64(atomic.LoadUint64(&mm.current)))
 			}

--- a/internal/monitor/memory_test.go
+++ b/internal/monitor/memory_test.go
@@ -46,5 +46,9 @@ var _ = Describe("Test memory monitor", func() {
 		mm.Decrement(&testSizeable{80})            // current 20 - unfenced
 		Expect(mm.current).To(BeEquivalentTo(20))  // current 20
 		Eventually(unfenced).Should(Receive())
+		Expect(func() {
+			mm.Decrement(&testSizeable{80})
+		}).Should(Panic()) // current underflow should panic
+		Expect(mm.current).To(BeEquivalentTo(0)) // current 0 - reset after panic
 	})
 })

--- a/internal/monitor/memory_test.go
+++ b/internal/monitor/memory_test.go
@@ -1,0 +1,50 @@
+package monitor
+
+import (
+	"sync"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+type testSizeable struct {
+	size uint64
+}
+
+func (ts *testSizeable) SizeOf() uint64 {
+	return ts.size
+}
+
+var _ = Describe("Test memory monitor", func() {
+	defer GinkgoRecover()
+	It("alarms on breaching watermark", func() {
+		mm := &memMonitor{
+			watermark:         100,
+			recoveryWatermark: 90,
+			breachCond:        sync.NewCond(&sync.Mutex{}),
+		}
+
+		mm.Increment(&testSizeable{101}) // current 101
+		Expect(mm.Breached()).To(BeTrue())
+		mm.Decrement(&testSizeable{101}) // current 0
+		Expect(mm.Breached()).To(BeFalse())
+		Expect(mm.current).To(BeEquivalentTo(0)) // current 0
+
+		mm.Increment(&testSizeable{99}) // current 99
+		Expect(mm.Breached()).To(BeFalse())
+		mm.Increment(&testSizeable{1}) // current 100
+		Expect(mm.Breached()).To(BeTrue())
+		Expect(mm.current).To(BeEquivalentTo(100)) // current 100
+
+		var unfenced = make(chan struct{})
+		go func() {
+			mm.Fence()
+			unfenced <- struct{}{}
+		}()
+		Eventually(unfenced).ShouldNot(Receive())
+		Expect(mm.current).To(BeEquivalentTo(100)) // current 100
+		mm.Decrement(&testSizeable{80})            // current 20 - unfenced
+		Expect(mm.current).To(BeEquivalentTo(20))  // current 20
+		Eventually(unfenced).Should(Receive())
+	})
+})

--- a/internal/monitor/monitor_suite_test.go
+++ b/internal/monitor/monitor_suite_test.go
@@ -1,0 +1,13 @@
+package monitor
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestMonitor(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Monitor Suite")
+}

--- a/pkg/job/job.go
+++ b/pkg/job/job.go
@@ -52,7 +52,7 @@ func NewJobAutoID(triggerAt time.Time, b []byte) *Job {
 
 // SizeOf returns the memory allocated for this job in bytes
 // including the size of the actual body payload + the fixed overhead costs
-// Implements monitor.MemAccountable interface
+// Implements monitor.Sizeable interface
 func (j *Job) SizeOf() uint64 {
 	return sizeOverhead + uint64(len(j.body)+len(j.id))
 }

--- a/pkg/job/job_test.go
+++ b/pkg/job/job_test.go
@@ -8,8 +8,8 @@ import (
 	. "github.com/onsi/gomega"
 	uuid "github.com/satori/go.uuid"
 
-	. "github.com/urjitbhatia/goyaad/pkg/job"
 	. "github.com/urjitbhatia/goyaad/internal/queue"
+	. "github.com/urjitbhatia/goyaad/pkg/job"
 	"github.com/urjitbhatia/goyaad/pkg/persistence"
 )
 

--- a/pkg/spoke/spoke_test.go
+++ b/pkg/spoke/spoke_test.go
@@ -9,10 +9,10 @@ import (
 	. "github.com/onsi/gomega"
 	uuid "github.com/satori/go.uuid"
 
-	. "github.com/urjitbhatia/goyaad/pkg/job"
 	. "github.com/urjitbhatia/goyaad/internal/queue"
-	. "github.com/urjitbhatia/goyaad/pkg/spoke"
+	. "github.com/urjitbhatia/goyaad/pkg/job"
 	"github.com/urjitbhatia/goyaad/pkg/persistence"
+	. "github.com/urjitbhatia/goyaad/pkg/spoke"
 )
 
 var _ = Describe("Test spokes", func() {

--- a/vendor/code.cloudfoundry.org/bytefmt/LICENSE
+++ b/vendor/code.cloudfoundry.org/bytefmt/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/code.cloudfoundry.org/bytefmt/NOTICE
+++ b/vendor/code.cloudfoundry.org/bytefmt/NOTICE
@@ -1,0 +1,20 @@
+Copyright (c) 2015-Present CloudFoundry.org Foundation, Inc. All Rights Reserved.
+
+This project contains software that is Copyright (c) 2013-2015 Pivotal Software, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+This project may include a number of subcomponents with separate
+copyright notices and license terms. Your use of these subcomponents
+is subject to the terms and conditions of each subcomponent's license,
+as noted in the LICENSE file.

--- a/vendor/code.cloudfoundry.org/bytefmt/README.md
+++ b/vendor/code.cloudfoundry.org/bytefmt/README.md
@@ -1,0 +1,19 @@
+bytefmt
+=======
+
+**Note**: This repository should be imported as `code.cloudfoundry.org/bytefmt`.
+
+Human-readable byte formatter.
+
+Example:
+
+```go
+bytefmt.ByteSize(100.5*bytefmt.MEGABYTE) // returns "100.5M"
+bytefmt.ByteSize(uint64(1024)) // returns "1K"
+```
+
+For documentation, please see http://godoc.org/code.cloudfoundry.org/bytefmt
+
+## Reporting issues and requesting features
+
+Please report all issues and feature requests in [cloudfoundry/diego-release](https://github.com/cloudfoundry/diego-release/issues).

--- a/vendor/code.cloudfoundry.org/bytefmt/bytes.go
+++ b/vendor/code.cloudfoundry.org/bytefmt/bytes.go
@@ -1,0 +1,121 @@
+// Package bytefmt contains helper methods and constants for converting to and from a human-readable byte format.
+//
+//	bytefmt.ByteSize(100.5*bytefmt.MEGABYTE) // "100.5M"
+//	bytefmt.ByteSize(uint64(1024)) // "1K"
+//
+package bytefmt
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+const (
+	BYTE = 1 << (10 * iota)
+	KILOBYTE
+	MEGABYTE
+	GIGABYTE
+	TERABYTE
+	PETABYTE
+	EXABYTE
+)
+
+var invalidByteQuantityError = errors.New("byte quantity must be a positive integer with a unit of measurement like M, MB, MiB, G, GiB, or GB")
+
+// ByteSize returns a human-readable byte string of the form 10M, 12.5K, and so forth.  The following units are available:
+//	E: Exabyte
+//	P: Petabyte
+//	T: Terabyte
+//	G: Gigabyte
+//	M: Megabyte
+//	K: Kilobyte
+//	B: Byte
+// The unit that results in the smallest number greater than or equal to 1 is always chosen.
+func ByteSize(bytes uint64) string {
+	unit := ""
+	value := float64(bytes)
+
+	switch {
+	case bytes >= EXABYTE:
+		unit = "E"
+		value = value / EXABYTE
+	case bytes >= PETABYTE:
+		unit = "P"
+		value = value / PETABYTE
+	case bytes >= TERABYTE:
+		unit = "T"
+		value = value / TERABYTE
+	case bytes >= GIGABYTE:
+		unit = "G"
+		value = value / GIGABYTE
+	case bytes >= MEGABYTE:
+		unit = "M"
+		value = value / MEGABYTE
+	case bytes >= KILOBYTE:
+		unit = "K"
+		value = value / KILOBYTE
+	case bytes >= BYTE:
+		unit = "B"
+	case bytes == 0:
+		return "0B"
+	}
+
+	result := strconv.FormatFloat(value, 'f', 1, 64)
+	result = strings.TrimSuffix(result, ".0")
+	return result + unit
+}
+
+// ToMegabytes parses a string formatted by ByteSize as megabytes.
+func ToMegabytes(s string) (uint64, error) {
+	bytes, err := ToBytes(s)
+	if err != nil {
+		return 0, err
+	}
+
+	return bytes / MEGABYTE, nil
+}
+
+// ToBytes parses a string formatted by ByteSize as bytes. Note binary-prefixed and SI prefixed units both mean a base-2 units
+// KB = K = KiB	= 1024
+// MB = M = MiB = 1024 * K
+// GB = G = GiB = 1024 * M
+// TB = T = TiB = 1024 * G
+// PB = P = PiB = 1024 * T
+// EB = E = EiB = 1024 * P
+func ToBytes(s string) (uint64, error) {
+	s = strings.TrimSpace(s)
+	s = strings.ToUpper(s)
+
+	i := strings.IndexFunc(s, unicode.IsLetter)
+
+	if i == -1 {
+		return 0, invalidByteQuantityError
+	}
+
+	bytesString, multiple := s[:i], s[i:]
+	bytes, err := strconv.ParseFloat(bytesString, 64)
+	if err != nil || bytes < 0 {
+		return 0, invalidByteQuantityError
+	}
+
+	switch multiple {
+	case "E", "EB", "EIB":
+		return uint64(bytes * EXABYTE), nil
+	case "P", "PB", "PIB":
+		return uint64(bytes * PETABYTE), nil
+	case "T", "TB", "TIB":
+		return uint64(bytes * TERABYTE), nil
+	case "G", "GB", "GIB":
+		return uint64(bytes * GIGABYTE), nil
+	case "M", "MB", "MIB":
+		return uint64(bytes * MEGABYTE), nil
+	case "K", "KB", "KIB":
+		return uint64(bytes * KILOBYTE), nil
+	case "B":
+		return uint64(bytes), nil
+	default:
+		return 0, invalidByteQuantityError
+	}
+}

--- a/vendor/code.cloudfoundry.org/bytefmt/package.go
+++ b/vendor/code.cloudfoundry.org/bytefmt/package.go
@@ -1,0 +1,1 @@
+package bytefmt // import "code.cloudfoundry.org/bytefmt"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -6,6 +6,8 @@ cloud.google.com/go/internal/optional
 cloud.google.com/go/internal/trace
 cloud.google.com/go/internal/version
 cloud.google.com/go/storage
+# code.cloudfoundry.org/bytefmt v0.0.0-20200125003136-cc367df7c24e
+code.cloudfoundry.org/bytefmt
 # github.com/Azure/azure-pipeline-go v0.2.1
 github.com/Azure/azure-pipeline-go/pipeline
 # github.com/Azure/azure-storage-blob-go v0.8.0


### PR DESCRIPTION
- This adds the ability to warn about high memory watermark similar to RabbitMQ's `vm_memory_high_watermark`
- Producers trying to Add jobs will be blocked till the memory usage falls below the watermark.
- Currently only job.Job size (including the actual body length) is accounted for - the rest of the data should be fairly static once we're up and running fully
- Since this is a bit of an experimental/advanced feature it is disabled by default. Can be enabled by using the `MEM_HIGH_WATERMARK` env variable like `MEM_HIGH_WATERMARK=10G`